### PR TITLE
feat: fluxo de criação e exibição de campeonatos

### DIFF
--- a/src/components/CreateChampionshipModal.jsx
+++ b/src/components/CreateChampionshipModal.jsx
@@ -1,0 +1,356 @@
+import { useState } from 'react';
+import ModalWrapper from './ModalWrapper.jsx';
+import {
+  MapPin,
+  Trophy,
+  SlidersHorizontal,
+  Lock,
+  ArrowRight,
+  ArrowLeft,
+} from 'lucide-react';
+import { useAuth } from '../hooks/useAuth';
+import { db } from '../firebase';
+import { collection, addDoc } from 'firebase/firestore';
+
+const Step1 = ({ formData, setFormData, handleCep }) => (
+  <div className="space-y-4">
+    <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+      <MapPin size={20} /> Localização e Data
+    </h3>
+    <input
+      type="text"
+      placeholder="Nome do Campeonato"
+      value={formData.name}
+      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+      className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+    />
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <input
+        type="text"
+        placeholder="CEP"
+        value={formData.cep}
+        onChange={handleCep}
+        maxLength="8"
+        className="md:col-span-1 w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+      />
+      <input
+        type="text"
+        placeholder="Rua"
+        value={formData.street}
+        disabled
+        className="md:col-span-2 w-full pl-4 pr-3 py-3 bg-gray-700/50 rounded-md text-gray-400 border border-gray-600"
+      />
+    </div>
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <input
+        type="text"
+        placeholder="Número"
+        value={formData.number}
+        onChange={(e) => setFormData({ ...formData, number: e.target.value })}
+        className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+      />
+      <input
+        type="text"
+        placeholder="Bairro"
+        value={formData.neighborhood}
+        disabled
+        className="w-full pl-4 pr-3 py-3 bg-gray-700/50 rounded-md text-gray-400 border border-gray-600"
+      />
+      <input
+        type="text"
+        placeholder="Cidade"
+        value={formData.city}
+        disabled
+        className="w-full pl-4 pr-3 py-3 bg-gray-700/50 rounded-md text-gray-400 border border-gray-600"
+      />
+    </div>
+    <div className="grid grid-cols-2 gap-4">
+      <input
+        type="date"
+        value={formData.date}
+        onChange={(e) => setFormData({ ...formData, date: e.target.value })}
+        className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+      />
+      <input
+        type="time"
+        value={formData.time}
+        onChange={(e) => setFormData({ ...formData, time: e.target.value })}
+        className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+      />
+    </div>
+  </div>
+);
+
+const Step2 = ({ formData, setFormData }) => (
+  <div className="space-y-4">
+    <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+      <Trophy size={20} /> Regras da Competição
+    </h3>
+    <select
+      value={formData.format}
+      onChange={(e) => setFormData({ ...formData, format: e.target.value })}
+      className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+    >
+      <option value="">Formato do Campeonato</option>
+      <option value="rachao">Rachão</option>
+      <option value="grupos_mata_mata">Fase de Grupos + Mata-Mata</option>
+      <option value="mata_mata">Somente Mata-Mata</option>
+      <option value="pontos_corridos">Pontos Corridos</option>
+    </select>
+    <select
+      value={formData.modality}
+      onChange={(e) => setFormData({ ...formData, modality: e.target.value })}
+      className="w-full pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+    >
+      <option value="">Modalidade</option>
+      <option value="futsal">Futsal</option>
+      <option value="society">Society</option>
+      <option value="campo">Campo</option>
+    </select>
+    <div>
+      <label className="text-sm text-gray-300">
+        Capacidade Máxima de Atletas
+      </label>
+      <input
+        type="number"
+        placeholder="Ex: 20"
+        value={formData.maxCapacity}
+        onChange={(e) =>
+          setFormData({ ...formData, maxCapacity: e.target.value })
+        }
+        className="w-full mt-1 pl-4 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+      />
+    </div>
+  </div>
+);
+
+const Step3 = ({ formData, setFormData }) => (
+  <div className="space-y-4">
+    <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+      <SlidersHorizontal size={20} /> Configurações Finais
+    </h3>
+    <div>
+      <label className="text-sm text-gray-300">Acesso ao Campeonato</label>
+      <div className="flex gap-4 mt-2">
+        <button
+          type="button"
+          onClick={() => setFormData({ ...formData, access: 'publico' })}
+          className={`flex-1 py-3 rounded-md ${
+            formData.access === 'publico'
+              ? 'bg-[var(--primary-color)]'
+              : 'bg-[var(--bg-color2)]'
+          }`}
+        >
+          Público
+        </button>
+        <button
+          type="button"
+          onClick={() => setFormData({ ...formData, access: 'privado' })}
+          className={`flex-1 py-3 rounded-md ${
+            formData.access === 'privado'
+              ? 'bg-[var(--primary-color)]'
+              : 'bg-[var(--bg-color2)]'
+          }`}
+        >
+          Privado
+        </button>
+      </div>
+    </div>
+    {formData.access === 'privado' && (
+      <div className="relative">
+        <Lock
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          size={20}
+        />
+        <input
+          type="password"
+          placeholder="Defina uma senha"
+          value={formData.password}
+          onChange={(e) =>
+            setFormData({ ...formData, password: e.target.value })
+          }
+          className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+        />
+      </div>
+    )}
+    <div>
+      <label className="text-sm text-gray-300">Montagem dos Times</label>
+      <div className="flex gap-4 mt-2">
+        <button
+          type="button"
+          onClick={() => setFormData({ ...formData, teamFormation: 'escolha' })}
+          className={`flex-1 py-3 rounded-md ${
+            formData.teamFormation === 'escolha'
+              ? 'bg-[var(--primary-color)]'
+              : 'bg-[var(--bg-color2)]'
+          }`}
+        >
+          Atletas escolhem
+        </button>
+        <button
+          type="button"
+          onClick={() => setFormData({ ...formData, teamFormation: 'sorteio' })}
+          className={`flex-1 py-3 rounded-md ${
+            formData.teamFormation === 'sorteio'
+              ? 'bg-[var(--primary-color)]'
+              : 'bg-[var(--bg-color2)]'
+          }`}
+        >
+          Sorteio automático
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+const CreateChampionshipModal = ({ onClose }) => {
+  const [step, setStep] = useState(1);
+  const { currentUser } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    cep: '',
+    street: '',
+    number: '',
+    neighborhood: '',
+    city: '',
+    date: '',
+    time: '',
+    format: '',
+    modality: '',
+    maxCapacity: '',
+    access: 'publico',
+    password: '',
+    teamFormation: 'escolha',
+  });
+
+  const handleCep = async (e) => {
+    const cep = e.target.value.replace(/\D/g, '');
+    setFormData({ ...formData, cep });
+    if (cep.length === 8) {
+      try {
+        const response = await fetch(`https://viacep.com.br/ws/${cep}/json/`);
+        const data = await response.json();
+        if (!data.erro) {
+          setFormData((prev) => ({
+            ...prev,
+            street: data.logradouro,
+            neighborhood: data.bairro,
+            city: data.localidade,
+          }));
+        }
+      } catch (error) {
+        console.error('Erro ao buscar CEP:', error);
+      }
+    }
+  };
+
+  const handleNext = () => setStep((prev) => prev + 1);
+  const handleBack = () => setStep((prev) => prev - 1);
+
+  const handleSubmit = async () => {
+    if (!currentUser) {
+      console.error('Usuário não está logado.');
+      return;
+    }
+
+    if (formData.modality === 'futsal' && parseInt(formData.maxCapacity) < 10) {
+      alert('Para Futsal (5v5), a capacidade mínima é de 10 atletas.');
+      setStep(2);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const finalData = {
+        ...formData,
+        organizerUid: currentUser.uid,
+        organizerName: currentUser.displayName || currentUser.name,
+        participants: [],
+        createdAt: new Date(),
+      };
+
+      const docRef = await addDoc(collection(db, 'championships'), finalData);
+      console.log('Campeonato salvo com ID: ', docRef.id);
+
+      onClose();
+    } catch (e) {
+      console.error('Erro ao adicionar documento: ', e);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const steps = [
+    <Step1
+      formData={formData}
+      setFormData={setFormData}
+      handleCep={handleCep}
+    />,
+    <Step2 formData={formData} setFormData={setFormData} />,
+    <Step3 formData={formData} setFormData={setFormData} />,
+  ];
+
+  return (
+    <ModalWrapper title="Criar Novo Campeonato" onClose={onClose}>
+      <div className="p-6 space-y-6">
+        <div className="flex items-center justify-center space-x-4">
+          {[1, 2, 3].map((s) => (
+            <div key={s} className="flex items-center">
+              <div
+                className={`w-8 h-8 rounded-full flex items-center justify-center font-bold ${
+                  step >= s
+                    ? 'bg-[var(--primary-color)] text-white'
+                    : 'bg-[var(--bg-color2)] text-gray-400'
+                }`}
+              >
+                {s}
+              </div>
+              {s < 3 && (
+                <div
+                  className={`w-12 h-1 ${
+                    step > s
+                      ? 'bg-[var(--primary-color)]'
+                      : 'bg-[var(--bg-color2)]'
+                  }`}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="min-h-[300px]">{steps[step - 1]}</div>
+
+        <div className="flex justify-between items-center pt-4 border-t border-gray-700">
+          <button
+            onClick={handleBack}
+            disabled={step === 1}
+            className="disabled:opacity-50 flex items-center gap-2 bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+          >
+            <ArrowLeft size={18} />
+            Voltar
+          </button>
+          {step < 3 ? (
+            <button
+              onClick={handleNext}
+              className="flex items-center gap-2 bg-[var(--primary-color)] hover:bg-[var(--primary-color-hover)] text-white font-bold py-2 px-4 rounded-lg transition-colors"
+            >
+              Avançar
+              <ArrowRight size={18} />
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg transition-colors disabled:opacity-50"
+            >
+              {isSubmitting ? 'Publicando...' : 'Publicar Campeonato'}
+            </button>
+          )}
+        </div>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default CreateChampionshipModal;

--- a/src/components/CreateChampionshipModal.jsx
+++ b/src/components/CreateChampionshipModal.jsx
@@ -8,8 +8,8 @@ import {
   ArrowRight,
   ArrowLeft,
 } from 'lucide-react';
-import { useAuth } from '../hooks/useAuth';
-import { db } from '../firebase';
+import { useAuth } from '../hooks/useAuth.js';
+import { db } from '../firebase.js';
 import { collection, addDoc } from 'firebase/firestore';
 
 const Step1 = ({ formData, setFormData, handleCep }) => (

--- a/src/pages/CourtsPage.jsx
+++ b/src/pages/CourtsPage.jsx
@@ -1,5 +1,4 @@
-import { Map, ArrowRight } from 'lucide-react';
-import mapaQuadras from '../assets/img/QuadrasImagem.png';
+import { ArrowRight, Search, PlusCircle } from 'lucide-react';
 
 const CourtsPage = () => {
   const championships = [
@@ -45,23 +44,29 @@ const CourtsPage = () => {
     <div className="p-4 md:p-8 bg-[var(--bg-color)] text-gray-200 min-h-full">
       <h1 className="text-3xl font-bold mb-6 text-white">Central de Quadras</h1>
 
-      <div className="relative h-64 lg:h-80 w-full rounded-lg overflow-hidden bg-[var(--bg-color2)] mb-8 shadow-lg">
-        {/* Usar a variável da imagem importada no 'src' */}
-        <img
-          src={mapaQuadras}
-          className="w-full h-full object-cover opacity-70"
-          alt="Mapa de quadras"
-        />
-        <div className="absolute inset-0 flex items-center justify-center bg-black/40">
-          <div className="text-center text-white p-4">
-            <Map size={48} className="mx-auto mb-2" />
-            <p className="font-semibold text-lg">Mapa interativo (simulação)</p>
-            <p className="text-sm">Movimente para ver os campeonatos</p>
-          </div>
+      {/* Container de Ações */}
+      <div className="mb-8 flex flex-col md:flex-row gap-4">
+        {/* Botão Organizar */}
+        <button className="flex-1 md:flex-none bg-[var(--primary-color)] text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2 hover:bg-[var(--primary-color-hover)] transition-colors">
+          <PlusCircle size={20} />
+          <span>ORGANIZAR</span>
+        </button>
+
+        {/* Busca por ID */}
+        <div className="relative flex-grow">
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            size={20}
+          />
+          <input
+            type="text"
+            placeholder="Buscar campeonato por ID..."
+            className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-lg text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+          />
         </div>
       </div>
 
-      <h2 className="font-semibold text-2xl mb-4 ttext-white">
+      <h2 className="font-semibold text-2xl mb-4 text-white">
         Campeonatos Próximos
       </h2>
 

--- a/src/pages/CourtsPage.jsx
+++ b/src/pages/CourtsPage.jsx
@@ -1,6 +1,10 @@
+import { useState } from 'react';
 import { ArrowRight, Search, PlusCircle } from 'lucide-react';
+import CreateChampionshipModal from '../components/CreateChampionshipModal';
 
 const CourtsPage = () => {
+  const [isCreateModalOpen, setCreateModalOpen] = useState(false);
+
   const championships = [
     {
       id: 1,
@@ -41,64 +45,77 @@ const CourtsPage = () => {
   ];
 
   return (
-    <div className="p-4 md:p-8 bg-[var(--bg-color)] text-gray-200 min-h-full">
-      <h1 className="text-3xl font-bold mb-6 text-white">Central de Quadras</h1>
+    <>
+      <div className="p-4 md:p-8 bg-[var(--bg-color)] text-gray-200 min-h-full">
+        <h1 className="text-3xl font-bold mb-6 text-white">
+          Central de Quadras
+        </h1>
 
-      {/* Container de Ações */}
-      <div className="mb-8 flex flex-col md:flex-row gap-4">
-        {/* Botão Organizar */}
-        <button className="flex-1 md:flex-none bg-[var(--primary-color)] text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2 hover:bg-[var(--primary-color-hover)] transition-colors">
-          <PlusCircle size={20} />
-          <span>ORGANIZAR</span>
-        </button>
+        {/* Container de Ações */}
+        <div className="mb-8 flex flex-col md:flex-row gap-4">
+          {/* Botão Organizar */}
+          <button
+            onClick={() => setCreateModalOpen(true)}
+            className="flex-1 md:flex-none bg-[var(--primary-color)] text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2 hover:bg-[var(--primary-color-hover)] transition-colors"
+          >
+            <PlusCircle size={20} />
+            <span>ORGANIZAR</span>
+          </button>
 
-        {/* Busca por ID */}
-        <div className="relative flex-grow">
-          <Search
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-            size={20}
-          />
-          <input
-            type="text"
-            placeholder="Buscar campeonato por ID..."
-            className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-lg text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
-          />
+          {/* Busca por ID */}
+          <div className="relative flex-grow">
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+              size={20}
+            />
+            <input
+              type="text"
+              placeholder="Buscar campeonato por ID..."
+              className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-lg text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+            />
+          </div>
+        </div>
+
+        <h2 className="font-semibold text-2xl mb-4 text-white">
+          Campeonatos Próximos
+        </h2>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {championships.map((champ) => (
+            <div
+              key={champ.id}
+              className="bg-[var(--bg-color2)] p-4 rounded-lg shadow-md flex items-center space-x-4 hover:shadow-lg hover:border-[var(--primary-color)] border border-transparent transition-all"
+            >
+              <div className="text-center bg-[var(--primary-color)] text-white rounded-lg p-3">
+                <p className="font-bold text-xl">{champ.date.split(' ')[0]}</p>
+                <p className="text-xs font-semibold">
+                  {champ.date.split(' ')[1]}
+                </p>
+              </div>
+              <div className="flex-grow">
+                <h3 className="font-bold text-lg text-gray-200">
+                  {champ.name}
+                </h3>
+                <p className="text-sm text-gray-400">{champ.court}</p>
+                <div className="flex items-center text-xs mt-2 space-x-3">
+                  <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
+                    {champ.format}
+                  </span>
+                  <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
+                    {champ.capacity}
+                  </span>
+                </div>
+              </div>
+              <ArrowRight className="text-gray-400" size={20} />
+            </div>
+          ))}
         </div>
       </div>
 
-      <h2 className="font-semibold text-2xl mb-4 text-white">
-        Campeonatos Próximos
-      </h2>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {championships.map((champ) => (
-          <div
-            key={champ.id}
-            className="bg-[var(--bg-color2)] p-4 rounded-lg shadow-md flex items-center space-x-4 hover:shadow-lg hover:border-[var(--primary-color)] border border-transparent transition-all"
-          >
-            <div className="text-center bg-[var(--primary-color)] text-white rounded-lg p-3">
-              <p className="font-bold text-xl">{champ.date.split(' ')[0]}</p>
-              <p className="text-xs font-semibold">
-                {champ.date.split(' ')[1]}
-              </p>
-            </div>
-            <div className="flex-grow">
-              <h3 className="font-bold text-lg text-gray-200">{champ.name}</h3>
-              <p className="text-sm text-gray-400">{champ.court}</p>
-              <div className="flex items-center text-xs mt-2 space-x-3">
-                <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
-                  {champ.format}
-                </span>
-                <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
-                  {champ.capacity}
-                </span>
-              </div>
-            </div>
-            <ArrowRight className="text-gray-400" size={20} />
-          </div>
-        ))}
-      </div>
-    </div>
+      {isCreateModalOpen && (
+        <CreateChampionshipModal onClose={() => setCreateModalOpen(false)} />
+      )}
+    </>
   );
 };
 

--- a/src/pages/CourtsPage.jsx
+++ b/src/pages/CourtsPage.jsx
@@ -1,119 +1,165 @@
-import { useState } from 'react';
-import { ArrowRight, Search, PlusCircle } from 'lucide-react';
-import CreateChampionshipModal from '../components/CreateChampionshipModal';
+import { useState, useEffect } from 'react';
+import { db } from '../firebase.js';
+import { collection, getDocs, query } from 'firebase/firestore';
+import { ArrowRight, Search, Plus, Clock } from 'lucide-react';
+import CreateChampionshipModal from '../components/CreateChampionshipModal.jsx';
 
 const CourtsPage = () => {
-  const [isCreateModalOpen, setCreateModalOpen] = useState(false);
+  const [championships, setChampionships] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const championships = [
-    {
-      id: 1,
-      name: 'Copa Delas',
-      court:
-        'Arena Mega Sports - R. Harry Dannenberg, 800 - Itaquera, São Paulo - SP, 08270-010',
-      date: '25 SET',
-      format: 'Society 7x7',
-      capacity: '8/12 times',
-    },
-    {
-      id: 2,
-      name: 'Liga da ZL',
-      court:
-        'R9 Academy Itaquera - Av. Itaquera, 7085 - Itaquera, São Paulo - SP, 08295-000',
-      date: '28 SET',
-      format: 'Futsal 5x5',
-      capacity: '10/16 times',
-    },
-    {
-      id: 3,
-      name: 'Copinha Churrasco',
-      court:
-        'SED Itaquerense - R. Antônio Soares Lara, 135 - Vila Carmosina, São Paulo - SP, 08210-060',
-      date: '02 OUT',
-      format: 'Campo 11x11',
-      capacity: '4/8 times',
-    },
-    {
-      id: 4,
-      name: 'Rachão Valendo Coca',
-      court:
-        'Arena JS - R. José Alves dos Santos, 46 - Vila Campanela, São Paulo - SP, 08220-450',
-      date: '02 OUT',
-      format: 'Campo 11x11',
-      capacity: '4/8 times',
-    },
-  ];
+  useEffect(() => {
+    const fetchChampionships = async () => {
+      setLoading(true);
+      try {
+        const championshipsCollection = collection(db, 'championships');
+        const q = query(championshipsCollection);
+        const querySnapshot = await getDocs(q);
+        const champsList = querySnapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+
+        champsList.sort((a, b) => {
+          const dateA = a.createdAt?.toDate() || 0;
+          const dateB = b.createdAt?.toDate() || 0;
+          return dateB - dateA;
+        });
+
+        setChampionships(champsList);
+      } catch (error) {
+        console.error('Erro ao buscar campeonatos:', error);
+      }
+      setLoading(false);
+    };
+
+    fetchChampionships();
+  }, [isModalOpen]);
+
+  const formatDate = (dateString) => {
+    if (!dateString || typeof dateString !== 'string') {
+      return { day: '??', month: '???' };
+    }
+    try {
+      // Trata a data como local para evitar problemas de fuso horário
+      const date = new Date(dateString.replace(/-/g, '/'));
+      const displayDay = date.getDate();
+      const displayMonth = date
+        .toLocaleString('pt-BR', { month: 'short' })
+        .toUpperCase();
+      return { day: displayDay, month: displayMonth };
+    } catch (e) {
+      console.error('Error formatting date:', e);
+      return { day: '??', month: '???' };
+    }
+  };
 
   return (
     <>
       <div className="p-4 md:p-8 bg-[var(--bg-color)] text-gray-200 min-h-full">
-        <h1 className="text-3xl font-bold mb-6 text-white">
-          Central de Quadras
-        </h1>
-
-        {/* Container de Ações */}
-        <div className="mb-8 flex flex-col md:flex-row gap-4">
-          {/* Botão Organizar */}
+        <header className="flex flex-col md:flex-row justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold text-white mb-4 md:mb-0">
+            Central de Campeonatos
+          </h1>
           <button
-            onClick={() => setCreateModalOpen(true)}
-            className="flex-1 md:flex-none bg-[var(--primary-color)] text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2 hover:bg-[var(--primary-color-hover)] transition-colors"
+            onClick={() => setIsModalOpen(true)}
+            className="w-full md:w-auto bg-[var(--primary-color)] hover:bg-[var(--primary-color-hover)] text-white font-bold py-2 px-6 rounded-lg flex items-center justify-center gap-2 transition-colors"
           >
-            <PlusCircle size={20} />
+            <Plus size={20} />
             <span>ORGANIZAR</span>
           </button>
+        </header>
 
-          {/* Busca por ID */}
-          <div className="relative flex-grow">
+        <div className="mb-8">
+          <div className="relative">
             <Search
               className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
               size={20}
             />
             <input
               type="text"
-              placeholder="Buscar campeonato por ID..."
-              className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-lg text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
+              placeholder="Buscar por ID do campeonato..."
+              className="w-full pl-10 pr-3 py-3 bg-[var(--bg-color2)] rounded-md text-white border border-gray-600 focus:ring-[var(--primary-color)] focus:border-[var(--primary-color)]"
             />
           </div>
         </div>
 
         <h2 className="font-semibold text-2xl mb-4 text-white">
-          Campeonatos Próximos
+          Campeonatos Abertos
         </h2>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {championships.map((champ) => (
-            <div
-              key={champ.id}
-              className="bg-[var(--bg-color2)] p-4 rounded-lg shadow-md flex items-center space-x-4 hover:shadow-lg hover:border-[var(--primary-color)] border border-transparent transition-all"
-            >
-              <div className="text-center bg-[var(--primary-color)] text-white rounded-lg p-3">
-                <p className="font-bold text-xl">{champ.date.split(' ')[0]}</p>
-                <p className="text-xs font-semibold">
-                  {champ.date.split(' ')[1]}
-                </p>
-              </div>
-              <div className="flex-grow">
-                <h3 className="font-bold text-lg text-gray-200">
-                  {champ.name}
-                </h3>
-                <p className="text-sm text-gray-400">{champ.court}</p>
-                <div className="flex items-center text-xs mt-2 space-x-3">
-                  <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
-                    {champ.format}
-                  </span>
-                  <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
-                    {champ.capacity}
-                  </span>
+        {loading ? (
+          <p>Carregando campeonatos...</p>
+        ) : championships.length > 0 ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {championships.map((champ) => {
+              const { day, month } = formatDate(champ.date);
+              return (
+                <div
+                  key={champ.id}
+                  className="bg-[var(--bg-color2)] p-4 rounded-lg shadow-md flex items-center space-x-4 hover:shadow-lg hover:border-[var(--primary-color)] border border-transparent transition-all cursor-pointer"
+                >
+                  <div className="text-center bg-[var(--primary-color)] text-white rounded-lg p-3 w-20 flex-shrink-0">
+                    <p className="font-bold text-2xl">{day}</p>
+                    <p className="text-xs font-semibold">{month}</p>
+                  </div>
+                  <div className="flex-grow overflow-hidden">
+                    <h3 className="font-bold text-lg text-gray-200 truncate">
+                      {champ.name}
+                    </h3>
+                    <p className="text-sm text-gray-400 truncate">
+                      Organizado por: {champ.organizerName}
+                    </p>
+                    <p className="text-sm text-gray-400 truncate">
+                      {champ.street
+                        ? `${champ.street}, ${champ.number || 's/n'}, ${
+                            champ.cep
+                          } - ${champ.city}`
+                        : 'Endereço não informado'}
+                    </p>
+                    <div className="flex items-center text-xs mt-2 space-x-3 flex-wrap gap-y-1">
+                      <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
+                        {champ.format}
+                      </span>
+                      <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300">
+                        {champ.participants.length}/{champ.maxCapacity} vagas
+                      </span>
+                      <span
+                        className={`px-2 py-1 rounded-full ${
+                          champ.access === 'publico'
+                            ? 'bg-green-800/50 text-green-300'
+                            : 'bg-red-800/50 text-red-300'
+                        }`}
+                      >
+                        {champ.access === 'publico' ? 'Público' : 'Privado'}
+                      </span>
+                      {champ.time && (
+                        <span className="bg-gray-700 px-2 py-1 rounded-full text-gray-300 flex items-center gap-1">
+                          <Clock size={12} /> {champ.time}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <ArrowRight
+                    className="text-gray-400 flex-shrink-0"
+                    size={20}
+                  />
                 </div>
-              </div>
-              <ArrowRight className="text-gray-400" size={20} />
-            </div>
-          ))}
-        </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-12 bg-[var(--bg-color2)] rounded-lg">
+            <p className="text-gray-400">
+              Nenhum campeonato encontrado no momento.
+            </p>
+          </div>
+        )}
       </div>
 
-      {isCreateModalOpen && (
-        <CreateChampionshipModal onClose={() => setCreateModalOpen(false)} />
+      {isModalOpen && (
+        <CreateChampionshipModal onClose={() => setIsModalOpen(false)} />
       )}
     </>
   );


### PR DESCRIPTION
Implementa o modal de criação de campeonatos em três etapas (CreateChampionshipModal.jsx), acionado pelo botão "ORGANIZAR" na CourtsPage.
Adiciona exibição de cards de campeonatos com informações detalhadas e vagas em tempo real.